### PR TITLE
Remove CUDA Dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ PHASER requires ROS and some other dependencies to be installed:
      libpcl-dev libnlopt-dev \
 ```
 
-
-__Important:__ Currently, PHASER also requires `nvcc` for compilation as most-recent experiments deal with performing the FFTs on the GPU.
-
 For the remaining package dependencies, run within the `caktin` workspace
 
 ```

--- a/phaser_common/include/phaser/common/data/base-datasource.h
+++ b/phaser_common/include/phaser/common/data/base-datasource.h
@@ -1,22 +1,22 @@
 #pragma once
 
-#include "phaser/model/point-cloud.h"
 #include <boost/function.hpp>
-
 #include <memory>
+
+#include "phaser/model/point-cloud.h"
 
 namespace data {
 
 class BaseDatasource {
-	public:
-    virtual void subscribeToPointClouds(
-        boost::function<void(const model::PointCloudPtr&)> func) = 0;
-		virtual void startStreaming(const uint32_t number_of_clouds = 0) = 0;
+ public:
+  virtual void subscribeToPointClouds(
+      boost::function<void(const model::PointCloudPtr&)> func) = 0;
+  virtual void startStreaming(const uint32_t number_of_clouds = 0) = 0;
 
-	protected:
-		std::vector<boost::function<void(const model::PointCloudPtr&)>> callbacks_;
+ protected:
+  std::vector<boost::function<void(const model::PointCloudPtr&)>> callbacks_;
 };
 
 using DatasourcePtr = std::shared_ptr<BaseDatasource>;
 
-} // namespace data
+}  // namespace data

--- a/phaser_common/include/phaser/common/data/datasource-ply.h
+++ b/phaser_common/include/phaser/common/data/datasource-ply.h
@@ -1,27 +1,27 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "phaser/common/data/base-datasource.h"
 #include "phaser/model/point-cloud.h"
-
-#include <vector>
-#include <memory>
 
 namespace data {
 
 class DatasourcePly : public BaseDatasource {
-	public:
-    DatasourcePly();
-    virtual void subscribeToPointClouds(
-        boost::function<void(const model::PointCloudPtr&)> func) override;
-		virtual void startStreaming(const uint32_t number_of_clouds = 0) override;
-    void setDatasetFolder(std::string&& datasource);
-	private:
-         std::vector<model::PointCloudPtr> readPly(
-             const std::string& directory, const uint32_t max_n_clouds);
-         std::string datasource_folder_;
+ public:
+  DatasourcePly();
+  virtual void subscribeToPointClouds(
+      boost::function<void(const model::PointCloudPtr&)> func) override;
+  virtual void startStreaming(const uint32_t number_of_clouds = 0) override;
+  void setDatasetFolder(std::string&& datasource);
 
+ private:
+  std::vector<model::PointCloudPtr> readPly(
+      const std::string& directory, const uint32_t max_n_clouds);
+  std::string datasource_folder_;
 };
 
 using DatasourcePlyPtr = std::unique_ptr<DatasourcePly>;
 
-} // namespace data
+}  // namespace data

--- a/phaser_common/include/phaser/common/data/datasource-ros.h
+++ b/phaser_common/include/phaser/common/data/datasource-ros.h
@@ -1,31 +1,31 @@
 #pragma once
 
-#include "phaser/common/data/base-datasource.h"
-
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
-
-#include <vector>
 #include <array>
 #include <functional>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <vector>
+
+#include "phaser/common/data/base-datasource.h"
 
 namespace data {
 
 class DatasourceRos : public BaseDatasource {
-  public:
-    explicit DatasourceRos(ros::NodeHandle& nh); 
+ public:
+  explicit DatasourceRos(ros::NodeHandle& nh);
 
-    virtual void subscribeToPointClouds(
-        boost::function<void(const model::PointCloudPtr&)> func) override;
-		virtual void startStreaming(const uint32_t number_of_clouds = 0) override;
-  private:
-		void pointCloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg);
+  virtual void subscribeToPointClouds(
+      boost::function<void(const model::PointCloudPtr&)> func) override;
+  virtual void startStreaming(const uint32_t number_of_clouds = 0) override;
 
-    ros::NodeHandle& nh_;
-    std::vector<ros::Subscriber> subscribers_;
-		bool started_;
-    uint32_t number_of_clouds_;
-    uint32_t processed_clouds_; 
+ private:
+  void pointCloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg);
+
+  ros::NodeHandle& nh_;
+  std::vector<ros::Subscriber> subscribers_;
+  bool started_;
+  uint32_t number_of_clouds_;
+  uint32_t processed_clouds_;
 };
 
-}
+}  // namespace data

--- a/phaser_common/include/phaser/common/metric-utils.h
+++ b/phaser_common/include/phaser/common/metric-utils.h
@@ -5,9 +5,9 @@
 namespace common {
 
 class MetricUtils {
-  public:
-    static float HausdorffDistance(const model::PointCloudPtr& cloud_a,                   
-      const model::PointCloudPtr& cloud_b);
+ public:
+  static float HausdorffDistance(
+      const model::PointCloudPtr& cloud_a, const model::PointCloudPtr& cloud_b);
 };
 
-} // namespace common
+}  // namespace common

--- a/phaser_common/include/phaser/common/point-cloud-utils.h
+++ b/phaser_common/include/phaser/common/point-cloud-utils.h
@@ -5,9 +5,8 @@
 namespace common {
 
 class PointCloudUtils {
-  public:
-    static model::PointCloud performZeroMeaning(
-        const model::PointCloud& cloud);
+ public:
+  static model::PointCloud performZeroMeaning(const model::PointCloud& cloud);
 };
 
-} // namespace common
+}  // namespace common

--- a/phaser_common/include/phaser/common/rotation-utils.h
+++ b/phaser_common/include/phaser/common/rotation-utils.h
@@ -1,12 +1,12 @@
 #ifndef PHASER_COMMON_ROTATION_UTILS_H_
 #define PHASER_COMMON_ROTATION_UTILS_H_
 
-#include "phaser/model/function-value.h"
-#include "phaser/model/point-cloud.h"
-
 #include <Eigen/Dense>
 #include <array>
 #include <vector>
+
+#include "phaser/model/function-value.h"
+#include "phaser/model/point-cloud.h"
 
 namespace common {
 

--- a/phaser_common/include/phaser/common/signal-utils.h
+++ b/phaser_common/include/phaser/common/signal-utils.h
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <array>
 #include <complex>
-
 #include <fftw3/fftw3.h>
 #include <glog/logging.h>
 

--- a/phaser_common/include/phaser/common/spherical-sampler.h
+++ b/phaser_common/include/phaser/common/spherical-sampler.h
@@ -2,6 +2,7 @@
 #define PHASER_COMMON_SPHERICAL_SAMPLER_H_
 
 #include <vector>
+
 #include "phaser/common/spherical-projection.h"
 #include "phaser/model/point-cloud.h"
 

--- a/phaser_common/include/phaser/common/statistic-utils.h
+++ b/phaser_common/include/phaser/common/statistic-utils.h
@@ -1,20 +1,20 @@
 #pragma once
 
 #include <chrono>
-#include <utility>
-#include <iostream>
 #include <functional>
+#include <iostream>
+#include <utility>
 
 namespace common {
 
-template <typename F, typename... Args> 
+template <typename F, typename... Args>
 double executeTimedFunction(F&& f, Args&&... args) {
   auto task = std::bind((std::forward<F>(f)), std::forward<Args>(args)...);
   auto start = std::chrono::high_resolution_clock::now();
   task();
   auto end = std::chrono::high_resolution_clock::now();
-  return std::chrono::duration_cast<std::chrono::milliseconds>(
-      end - start).count();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+      .count();
 }
 
-}
+}  // namespace common

--- a/phaser_common/include/phaser/common/statistics-manager.h
+++ b/phaser_common/include/phaser/common/statistics-manager.h
@@ -6,21 +6,21 @@
 namespace common {
 
 class StatisticsManager {
-  public: 
-    explicit StatisticsManager(std::string &&name);
-    explicit StatisticsManager(const std::string &name);
+ public:
+  explicit StatisticsManager(std::string&& name);
+  explicit StatisticsManager(const std::string& name);
 
-    void emplaceValue(std::string&& key, double value);
-    void emplaceValue(const std::string& key, double value);
-    std::vector<double> getValuesForKey(const std::string&key) const;
-    std::vector<double> getValuesForKey(std::string&& key) const;
-    std::size_t count(std::string&& key) const;
+  void emplaceValue(std::string&& key, double value);
+  void emplaceValue(const std::string& key, double value);
+  std::vector<double> getValuesForKey(const std::string& key) const;
+  std::vector<double> getValuesForKey(std::string&& key) const;
+  std::size_t count(std::string&& key) const;
 
-    void mergeManager(const StatisticsManager& manager);
+  void mergeManager(const StatisticsManager& manager);
 
-  private:
-    const std::string reference_name_;
-    std::map<std::string, std::vector<double>> statistics_;
+ private:
+  const std::string reference_name_;
+  std::map<std::string, std::vector<double>> statistics_;
 };
 
-} // namespace
+}  // namespace common

--- a/phaser_common/include/phaser/common/translation-utils.h
+++ b/phaser_common/include/phaser/common/translation-utils.h
@@ -1,11 +1,11 @@
 #ifndef PHASER_COMMON_TRANSLATION_UTILS_H_
 #define PHASER_COMMON_TRANSLATION_UTILS_H_
 
-#include "phaser/model/function-value.h"
-#include "phaser/model/point-cloud.h"
-
 #include <Eigen/Dense>
 #include <vector>
+
+#include "phaser/model/function-value.h"
+#include "phaser/model/point-cloud.h"
 
 namespace common {
 

--- a/phaser_common/include/phaser/distribution/bingham-mixture.h
+++ b/phaser_common/include/phaser/distribution/bingham-mixture.h
@@ -1,12 +1,12 @@
 #ifndef PHASER_DISTRIBUTION_BINGHAM_MIXTURE_H_
 #define PHASER_DISTRIBUTION_BINGHAM_MIXTURE_H_
 
-#include "phaser/distribution/base-distribution.h"
-#include "phaser/distribution/bingham.h"
-
 #include <Eigen/Dense>
 #include <memory>
 #include <vector>
+
+#include "phaser/distribution/base-distribution.h"
+#include "phaser/distribution/bingham.h"
 
 namespace common {
 

--- a/phaser_common/include/phaser/distribution/bingham.h
+++ b/phaser_common/include/phaser/distribution/bingham.h
@@ -11,11 +11,11 @@
 #ifndef PHASER_DISTRIBUTION_BINGHAM_H_
 #define PHASER_DISTRIBUTION_BINGHAM_H_
 
-#include "phaser/distribution/base-distribution.h"
-
 #include <Eigen/Dense>
 #include <memory>
 #include <string>
+
+#include "phaser/distribution/base-distribution.h"
 
 namespace common {
 

--- a/phaser_common/include/phaser/distribution/gaussian-mixture.h
+++ b/phaser_common/include/phaser/distribution/gaussian-mixture.h
@@ -1,13 +1,13 @@
 #ifndef PHASER_DISTRIBUTION_GAUSSIAN_MIXTURE_H_
 #define PHASER_DISTRIBUTION_GAUSSIAN_MIXTURE_H_
 
-#include "phaser/distribution/base-distribution.h"
-#include "phaser/distribution/gaussian.h"
-
 #include <Eigen/Dense>
 #include <memory>
 #include <utility>
 #include <vector>
+
+#include "phaser/distribution/base-distribution.h"
+#include "phaser/distribution/gaussian.h"
 
 namespace common {
 

--- a/phaser_common/include/phaser/distribution/gaussian.h
+++ b/phaser_common/include/phaser/distribution/gaussian.h
@@ -1,19 +1,19 @@
 #ifndef PHASER_DISTRIBUTION_GAUSSIAN_H_
 #define PHASER_DISTRIBUTION_GAUSSIAN_H_
 
-#include "phaser/distribution/base-distribution.h"
-
 #include <Eigen/Dense>
 #include <memory>
 #include <utility>
+
+#include "phaser/distribution/base-distribution.h"
 
 namespace common {
 
 class Gaussian : public BaseDistribution {
  public:
   explicit Gaussian(const Eigen::VectorXd& mu, const Eigen::MatrixXd& cov);
-  explicit Gaussian(const Eigen::MatrixXd& samples,
-    const Eigen::VectorXd& weights);
+  explicit Gaussian(
+      const Eigen::MatrixXd& samples, const Eigen::VectorXd& weights);
   virtual ~Gaussian() = default;
   Eigen::VectorXd getEstimate() const override;
 
@@ -29,8 +29,8 @@ class Gaussian : public BaseDistribution {
   Eigen::VectorXd weights_;
 
  private:
-  void setMeanAndCov(const Eigen::MatrixXd& samples,
-     const Eigen::VectorXd& weights);
+  void setMeanAndCov(
+      const Eigen::MatrixXd& samples, const Eigen::VectorXd& weights);
 
   Eigen::VectorXd mu_;
   Eigen::MatrixXd cov_;

--- a/phaser_common/include/phaser/model/function-value.h
+++ b/phaser_common/include/phaser/model/function-value.h
@@ -1,9 +1,8 @@
 #ifndef PHASER_MODEL_FUNCTION_VALUE_H_
 #define PHASER_MODEL_FUNCTION_VALUE_H_
 
-#include <vector>
-
 #include <Eigen/Dense>
+#include <vector>
 
 #include "phaser/common/point-types.h"
 

--- a/phaser_common/include/phaser/model/packet.h
+++ b/phaser_common/include/phaser/model/packet.h
@@ -1,19 +1,18 @@
 #pragma once
 
-#include "phaser/model/point.h"
-
 #include <memory>
 #include <vector>
+
+#include "phaser/model/point.h"
 
 namespace model {
 
 class Packet {
-  public:
-    Packet();
+ public:
+  Packet();
 
-  private:
-    std::vector<PointXYZIf> points_;
-
+ private:
+  std::vector<PointXYZIf> points_;
 };
 
-} // namespace model
+}  // namespace model

--- a/phaser_common/include/phaser/model/point-cloud.h
+++ b/phaser_common/include/phaser/model/point-cloud.h
@@ -1,18 +1,17 @@
 #ifndef PHASER_MODEL_POINT_CLOUD_H_
 #define PHASER_MODEL_POINT_CLOUD_H_
 
+#include <memory>
+#include <pcl/common/projection_matrix.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/point_types.h>
+#include <string>
+#include <vector>
+
 #include "phaser/common/point-types.h"
 #include "phaser/model/function-value.h"
 #include "phaser/model/ply-point-cloud.h"
 #include "phaser/model/point.h"
-
-#include <pcl/common/projection_matrix.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/point_types.h>
-
-#include <memory>
-#include <string>
-#include <vector>
 
 namespace model {
 

--- a/phaser_common/include/phaser/model/registration-result.h
+++ b/phaser_common/include/phaser/model/registration-result.h
@@ -1,13 +1,13 @@
 #ifndef PHASER_MODEL_REGISTRATION_RESULT_H_
 #define PHASER_MODEL_REGISTRATION_RESULT_H_
 
-#include "phaser/distribution/base-distribution.h"
-#include "phaser/model/point-cloud.h"
-#include "phaser/model/state.h"
-
 #include <array>
 #include <memory>
 #include <vector>
+
+#include "phaser/distribution/base-distribution.h"
+#include "phaser/model/point-cloud.h"
+#include "phaser/model/state.h"
 
 namespace model {
 

--- a/phaser_common/src/common/data/datasource-ply.cc
+++ b/phaser_common/src/common/data/datasource-ply.cc
@@ -1,8 +1,9 @@
 #include "phaser/common/data/datasource-ply.h"
-#include "phaser/common/data/file-system-helper.h"
 
 #include <boost/filesystem.hpp>
 #include <glog/logging.h>
+
+#include "phaser/common/data/file-system-helper.h"
 
 DEFINE_string(
     PlyReadDirectory, "", "Defines the directory to read the PLYs from.");

--- a/phaser_common/src/common/data/datasource-ros.cc
+++ b/phaser_common/src/common/data/datasource-ros.cc
@@ -1,6 +1,7 @@
 #include "phaser/common/data/datasource-ros.h"
-#include <pcl_conversions/pcl_conversions.h>
+
 #include <glog/logging.h>
+#include <pcl_conversions/pcl_conversions.h>
 
 DEFINE_string(
     point_cloud_topic, "/os1_cloud_node/points",
@@ -32,12 +33,12 @@ void DatasourceRos::startStreaming(const uint32_t number_of_clouds) {
 
 void DatasourceRos::pointCloudCallback(
     const sensor_msgs::PointCloud2ConstPtr& msg) {
-  if (!started_) return;
+  if (!started_)
+    return;
   if (number_of_clouds_ != 0 && ++processed_clouds_ > number_of_clouds_)
     return;
 
-  common::PointCloud_tPtr input_cloud(
-      new common::PointCloud_t);
+  common::PointCloud_tPtr input_cloud(new common::PointCloud_t);
 
   pcl::fromROSMsg(*msg, *input_cloud);
   model::PointCloudPtr cur_cloud =

--- a/phaser_common/src/common/data/file-system-helper.cc
+++ b/phaser_common/src/common/data/file-system-helper.cc
@@ -5,8 +5,8 @@
 
 namespace data {
 
-void FileSystemHelper::readDirectory(const std::string& directory,
-    std::vector<std::string>* files) {
+void FileSystemHelper::readDirectory(
+    const std::string& directory, std::vector<std::string>* files) {
   boost::filesystem::path p(directory);
   if (!boost::filesystem::exists(p)) {
     LOG(FATAL) << "PLY directory does not exist!";

--- a/phaser_common/src/common/data/ply-helper.cc
+++ b/phaser_common/src/common/data/ply-helper.cc
@@ -1,10 +1,9 @@
-#include <fstream>
+#include "phaser/common/data/ply-helper.h"
 
+#include <fstream>
 #include <glog/logging.h>
 
 #include "tinyply/tinyply.h"
-
-#include "phaser/common/data/ply-helper.h"
 
 DEFINE_string(
     phaser_ply_intensity_str, "intensity",

--- a/phaser_common/src/common/math-utils.cc
+++ b/phaser_common/src/common/math-utils.cc
@@ -1,4 +1,5 @@
 #include "phaser/common/math-utils.h"
+
 #include <chrono>
 #include <numeric>
 #include <random>

--- a/phaser_common/src/common/metric-utils.cc
+++ b/phaser_common/src/common/metric-utils.cc
@@ -1,43 +1,41 @@
 #include "phaser/common/metric-utils.h"
-#include <pcl/search/kdtree.h>
 
+#include <pcl/search/kdtree.h>
 
 namespace common {
 
-float MetricUtils::HausdorffDistance(const model::PointCloudPtr& cloud_a,                   
-    const model::PointCloudPtr& cloud_b) {
+float MetricUtils::HausdorffDistance(
+    const model::PointCloudPtr& cloud_a, const model::PointCloudPtr& cloud_b) {
   // Compare A to B: sup_a inf_b d(a,b)
-  pcl::search::KdTree<common::Point_t> tree_b;                              
-  tree_b.setInputCloud (cloud_b->getRawCloud());                            
-  float max_dist_a = -std::numeric_limits<float>::max();                    
-  for (const common::Point_t &point : cloud_a->getRawCloud()->points)                  
-  {                                                                         
-   std::vector<int> indices(1);
-   std::vector<float> sqr_distances(1);
-                                                                           
-   tree_b.nearestKSearch(point, 1, indices, sqr_distances);               
-   if (sqr_distances[0] > max_dist_a)                                      
-     max_dist_a = sqr_distances[0];                                        
-  }                                                                         
-                                                                           
+  pcl::search::KdTree<common::Point_t> tree_b;
+  tree_b.setInputCloud(cloud_b->getRawCloud());
+  float max_dist_a = -std::numeric_limits<float>::max();
+  for (const common::Point_t& point : cloud_a->getRawCloud()->points) {
+    std::vector<int> indices(1);
+    std::vector<float> sqr_distances(1);
+
+    tree_b.nearestKSearch(point, 1, indices, sqr_distances);
+    if (sqr_distances[0] > max_dist_a)
+      max_dist_a = sqr_distances[0];
+  }
+
   // compare B to A: sup_a inf_b d(a,b)
-  pcl::search::KdTree<common::Point_t> tree_a;                              
-  tree_a.setInputCloud (cloud_a->getRawCloud());                            
-  float max_dist_b = -std::numeric_limits<float>::max();                    
-  for (const common::Point_t &point : cloud_b->getRawCloud()->points)                  
-  {                                                                         
-   std::vector<int> indices(1);                                           
-   std::vector<float> sqr_distances(1);                                   
-                                                                           
-   tree_a.nearestKSearch(point, 1, indices, sqr_distances);               
-   if (sqr_distances[0] > max_dist_b)                                      
-     max_dist_b = sqr_distances[0];                                        
-  }                                                                         
-                                                                           
-  max_dist_a = std::sqrt(max_dist_a);                                      
-  max_dist_b = std::sqrt(max_dist_b);                                      
-                                                                           
+  pcl::search::KdTree<common::Point_t> tree_a;
+  tree_a.setInputCloud(cloud_a->getRawCloud());
+  float max_dist_b = -std::numeric_limits<float>::max();
+  for (const common::Point_t& point : cloud_b->getRawCloud()->points) {
+    std::vector<int> indices(1);
+    std::vector<float> sqr_distances(1);
+
+    tree_a.nearestKSearch(point, 1, indices, sqr_distances);
+    if (sqr_distances[0] > max_dist_b)
+      max_dist_b = sqr_distances[0];
+  }
+
+  max_dist_a = std::sqrt(max_dist_a);
+  max_dist_b = std::sqrt(max_dist_b);
+
   return std::max(max_dist_a, max_dist_b);
 }
 
-} // namespace common
+}  // namespace common

--- a/phaser_common/src/common/rotation-utils.cc
+++ b/phaser_common/src/common/rotation-utils.cc
@@ -1,8 +1,7 @@
 #include "phaser/common/rotation-utils.h"
 
-#include <glog/logging.h>
-
 #include <cmath>
+#include <glog/logging.h>
 
 namespace common {
 

--- a/phaser_common/src/common/spherical-projection.cc
+++ b/phaser_common/src/common/spherical-projection.cc
@@ -1,7 +1,7 @@
 #include "phaser/common/spherical-projection.h"
 
-#include <glog/logging.h>
 #include <cmath>
+#include <glog/logging.h>
 
 namespace common {
 
@@ -10,7 +10,7 @@ void SphericalProjection::convertPointCloud(model::PointCloud* cloud) {
 }
 
 model::PointCloud SphericalProjection::convertPointCloudCopy(
-    const model::PointCloud &cloud) {
+    const model::PointCloud& cloud) {
   model::PointCloud cloned = cloud.clone();
   naiveProjection(cloud, &cloned);
   return cloned;
@@ -20,7 +20,7 @@ void SphericalProjection::naiveProjection(
     const model::PointCloud& cloud_in, model::PointCloud* cloud_out) {
   const uint32_t n_points = cloud_in.size();
   for (uint32_t i = 0u; i < n_points; ++i) {
-    const common::Point_t &point = cloud_in.pointAt(i);
+    const common::Point_t& point = cloud_in.pointAt(i);
     // Calculate the distance to the point.
     const double dist_xy = std::sqrt(point.x * point.x + point.y * point.y);
     const double dist = std::sqrt(dist_xy * dist_xy + point.z * point.z);

--- a/phaser_common/src/common/spherical-sampler.cc
+++ b/phaser_common/src/common/spherical-sampler.cc
@@ -1,4 +1,5 @@
 #include "phaser/common/spherical-sampler.h"
+
 #include <cmath>
 #include <glog/logging.h>
 

--- a/phaser_common/src/common/statistics-manager.cc
+++ b/phaser_common/src/common/statistics-manager.cc
@@ -4,11 +4,11 @@
 
 namespace common {
 
-StatisticsManager::StatisticsManager(std::string &&name)
-  : reference_name_(name) {}
+StatisticsManager::StatisticsManager(std::string&& name)
+    : reference_name_(name) {}
 
-StatisticsManager::StatisticsManager(const std::string &name)
-  : reference_name_(name) {}
+StatisticsManager::StatisticsManager(const std::string& name)
+    : reference_name_(name) {}
 
 void StatisticsManager::emplaceValue(std::string&& key, double value) {
   statistics_[key].emplace_back(value);
@@ -19,14 +19,16 @@ void StatisticsManager::emplaceValue(const std::string& key, double value) {
 }
 
 std::vector<double> StatisticsManager::getValuesForKey(
-    const std::string &key) const {
-  if (statistics_.count(key) == 0) return std::vector<double>();
+    const std::string& key) const {
+  if (statistics_.count(key) == 0)
+    return std::vector<double>();
   return statistics_.at(key);
 }
 
-std::vector<double> StatisticsManager::getValuesForKey(std::string&& key) 
-    const {
-  if (statistics_.count(key) == 0) return std::vector<double>();
+std::vector<double> StatisticsManager::getValuesForKey(
+    std::string&& key) const {
+  if (statistics_.count(key) == 0)
+    return std::vector<double>();
   return statistics_.at(key);
 }
 
@@ -38,5 +40,4 @@ std::size_t StatisticsManager::count(std::string&& key) const {
   return statistics_.count(key);
 }
 
-
-} // namespace common
+}  // namespace common

--- a/phaser_common/src/common/test-worker.cc
+++ b/phaser_common/src/common/test-worker.cc
@@ -1,9 +1,8 @@
 #include "phaser/common/test-worker.h"
 
 #include <chrono>
-#include <thread>
-
 #include <glog/logging.h>
+#include <thread>
 
 namespace common {
 

--- a/phaser_common/src/common/translation-utils.cc
+++ b/phaser_common/src/common/translation-utils.cc
@@ -1,6 +1,6 @@
 #include "phaser/common/translation-utils.h"
-#include <cmath>
 
+#include <cmath>
 #include <glog/logging.h>
 
 namespace common {

--- a/phaser_common/src/distribution/bingham-mle.cc
+++ b/phaser_common/src/distribution/bingham-mle.cc
@@ -1,7 +1,9 @@
 #include "phaser/distribution/bingham-mle.h"
+
 #include <Eigen/Dense>
 #include <glog/logging.h>
 #include <iostream>
+
 #include "phaser/distribution/bingham-normalization-constant.h"
 
 Eigen::VectorXd BinghamMLE::compute(Eigen::VectorXd* omega) {

--- a/phaser_common/src/distribution/bingham-objective.cc
+++ b/phaser_common/src/distribution/bingham-objective.cc
@@ -1,7 +1,8 @@
 #include "phaser/distribution/bingham-objective.h"
-#include "phaser/distribution/bingham.h"
 
 #include <glog/logging.h>
+
+#include "phaser/distribution/bingham.h"
 
 namespace common {
 

--- a/phaser_common/src/distribution/bingham-opt-mle.cc
+++ b/phaser_common/src/distribution/bingham-opt-mle.cc
@@ -1,9 +1,10 @@
 #include "phaser/distribution/bingham-opt-mle.h"
-#include "phaser/distribution/bingham-objective.h"
 
 #include <glog/logging.h>
 #include <nlopt.hpp>
 #include <vector>
+
+#include "phaser/distribution/bingham-objective.h"
 
 namespace common {
 

--- a/phaser_common/src/distribution/bingham.cc
+++ b/phaser_common/src/distribution/bingham.cc
@@ -1,8 +1,4 @@
 #include "phaser/distribution/bingham.h"
-#include "phaser/common/math-utils.h"
-#include "phaser/distribution/bingham-mle.h"
-#include "phaser/distribution/bingham-normalization-constant.h"
-#include "phaser/distribution/bingham-opt-mle.h"
 
 #include <algorithm>
 #include <boost/math/special_functions/bessel.hpp>
@@ -10,6 +6,11 @@
 #include <glog/logging.h>
 #include <iostream>
 #include <vector>
+
+#include "phaser/common/math-utils.h"
+#include "phaser/distribution/bingham-mle.h"
+#include "phaser/distribution/bingham-normalization-constant.h"
+#include "phaser/distribution/bingham-opt-mle.h"
 
 namespace common {
 
@@ -48,7 +49,7 @@ Eigen::MatrixXd Bingham::gaussianCovariance(bool angle) {
     sample(&samples, sample_count);
     Eigen::VectorXd m = mode();
     Eigen::MatrixXd zero_samples = samples - m.replicate(samples.rows(), 1);
-    return zero_samples*zero_samples.transpose()/sample_count;
+    return zero_samples * zero_samples.transpose() / sample_count;
   }
 }
 

--- a/phaser_common/src/distribution/gaussian.cc
+++ b/phaser_common/src/distribution/gaussian.cc
@@ -11,8 +11,8 @@ Gaussian::Gaussian(const Eigen::VectorXd& mu, const Eigen::MatrixXd& cov)
   CHECK_EQ(cov_.cols(), 3);
 }
 
-Gaussian::Gaussian(const Eigen::MatrixXd& samples,
-    const Eigen::VectorXd& weights) {
+Gaussian::Gaussian(
+    const Eigen::MatrixXd& samples, const Eigen::VectorXd& weights) {
   CHECK_GT(samples.cols(), 0);
   CHECK_GT(samples.rows(), 0);
   CHECK_EQ(samples.cols(), weights.rows());
@@ -45,8 +45,8 @@ std::pair<Eigen::VectorXd, Eigen::MatrixXd> Gaussian::getParameters() const {
   return std::make_pair(mu_, cov_);
 }
 
-void Gaussian::setMeanAndCov(const Eigen::MatrixXd& samples,
-   const Eigen::VectorXd& weights) {
+void Gaussian::setMeanAndCov(
+    const Eigen::MatrixXd& samples, const Eigen::VectorXd& weights) {
   mu_ = samples * weights;
   Eigen::MatrixXd zero_mean_samples = samples.colwise() - mu_;
   Eigen::MatrixXd sqrt_weights = weights.transpose().array().sqrt();

--- a/phaser_common/src/model/function-value.cc
+++ b/phaser_common/src/model/function-value.cc
@@ -1,9 +1,8 @@
 #include "phaser/model/function-value.h"
 
 #include <algorithm>
-#include <numeric>
-
 #include <glog/logging.h>
+#include <numeric>
 
 namespace model {
 

--- a/phaser_common/src/model/point-cloud.cc
+++ b/phaser_common/src/model/point-cloud.cc
@@ -1,17 +1,17 @@
 #include "phaser/model/point-cloud.h"
-#include "phaser/common/core-gflags.h"
-#include "phaser/common/data/file-system-helper.h"
-#include "phaser/common/data/ply-helper.h"
 
+#include <chrono>
+#include <glog/logging.h>
+#include <omp.h>
 #include <pcl/common/io.h>
 #include <pcl/common/transforms.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/io/ply_io.h>
 #include <pcl/kdtree/impl/kdtree_flann.hpp>
 
-#include <chrono>
-#include <glog/logging.h>
-#include <omp.h>
+#include "phaser/common/core-gflags.h"
+#include "phaser/common/data/file-system-helper.h"
+#include "phaser/common/data/ply-helper.h"
 
 DEFINE_string(
     PlyWriteDirectory, "", "Defines the directory to store the point clouds.");

--- a/phaser_common/src/model/registration-result.cc
+++ b/phaser_common/src/model/registration-result.cc
@@ -1,7 +1,8 @@
 #include "phaser/model/registration-result.h"
-#include "phaser/common/rotation-utils.h"
 
 #include <glog/logging.h>
+
+#include "phaser/common/rotation-utils.h"
 
 namespace model {
 
@@ -92,8 +93,8 @@ void RegistrationResult::setRotationCorrelation(
   rotation_correlation_ = rot;
 }
 
-const std::vector<double>& RegistrationResult::getRotationCorrelation() const
-    noexcept {
+const std::vector<double>& RegistrationResult::getRotationCorrelation()
+    const noexcept {
   return rotation_correlation_;
 }
 

--- a/phaser_common/src/model/state.cc
+++ b/phaser_common/src/model/state.cc
@@ -1,8 +1,9 @@
 #include "phaser/model/state.h"
-#include "phaser/distribution/bingham.h"
-#include "phaser/distribution/gaussian.h"
 
 #include <glog/logging.h>
+
+#include "phaser/distribution/bingham.h"
+#include "phaser/distribution/gaussian.h"
 
 namespace model {
 

--- a/phaser_common/test/common/thread-pool-test.cc
+++ b/phaser_common/test/common/thread-pool-test.cc
@@ -1,16 +1,16 @@
-#include <chrono>
-#include <cmath>
-#include <memory>
-#include <random>
+#include "phaser/common/thread-pool.h"
 
 #include <Eigen/Dense>
+#include <chrono>
+#include <cmath>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <random>
 
 #include "phaser/common/test-worker.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
-#include "phaser/common/thread-pool.h"
 
 namespace common {
 

--- a/phaser_common/test/distribution/bingham-mixture-test.cc
+++ b/phaser_common/test/distribution/bingham-mixture-test.cc
@@ -1,7 +1,4 @@
 #include "phaser/distribution/bingham-mixture.h"
-#include "phaser/common/rotation-utils.h"
-#include "phaser/common/test/testing-entrypoint.h"
-#include "phaser/common/test/testing-predicates.h"
 
 #include <Eigen/Dense>
 #include <chrono>
@@ -10,6 +7,10 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
+
+#include "phaser/common/rotation-utils.h"
+#include "phaser/common/test/testing-entrypoint.h"
+#include "phaser/common/test/testing-predicates.h"
 
 namespace common {
 

--- a/phaser_common/test/distribution/bingham-test.cc
+++ b/phaser_common/test/distribution/bingham-test.cc
@@ -1,7 +1,4 @@
 #include "phaser/distribution/bingham.h"
-#include "phaser/common/rotation-utils.h"
-#include "phaser/common/test/testing-entrypoint.h"
-#include "phaser/common/test/testing-predicates.h"
 
 #include <Eigen/Dense>
 #include <chrono>
@@ -10,6 +7,10 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
+
+#include "phaser/common/rotation-utils.h"
+#include "phaser/common/test/testing-entrypoint.h"
+#include "phaser/common/test/testing-predicates.h"
 
 namespace common {
 
@@ -104,8 +105,8 @@ TEST_F(BinghamTest, sampleDeterministicTest) {
 
   Eigen::MatrixXd true_samples(2, 3);
   Eigen::RowVector3d true_weights(0.3333333, 0.3333333, 0.3333333);
-  true_samples << 0, 0.550363580623329, -0.550363580623329,
-    1, 0.834925103900624, 0.834925103900624;
+  true_samples << 0, 0.550363580623329, -0.550363580623329, 1,
+      0.834925103900624, 0.834925103900624;
 
   EXPECT_NEAR_EIGEN(deterministic_weights, true_weights, 1e-4);
   EXPECT_NEAR_EIGEN(deterministic_samples, true_samples, 1e-4);

--- a/phaser_common/test/distribution/gaussian-mixture-test.cc
+++ b/phaser_common/test/distribution/gaussian-mixture-test.cc
@@ -1,6 +1,4 @@
 #include "phaser/distribution/gaussian-mixture.h"
-#include "phaser/common/test/testing-entrypoint.h"
-#include "phaser/common/test/testing-predicates.h"
 
 #include <Eigen/Dense>
 #include <chrono>
@@ -9,6 +7,9 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
+
+#include "phaser/common/test/testing-entrypoint.h"
+#include "phaser/common/test/testing-predicates.h"
 
 namespace common {
 

--- a/phaser_common/test/distribution/gaussian-test.cc
+++ b/phaser_common/test/distribution/gaussian-test.cc
@@ -1,6 +1,4 @@
 #include "phaser/distribution/gaussian.h"
-#include "phaser/common/test/testing-entrypoint.h"
-#include "phaser/common/test/testing-predicates.h"
 
 #include <Eigen/Dense>
 #include <chrono>
@@ -9,6 +7,9 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
+
+#include "phaser/common/test/testing-entrypoint.h"
+#include "phaser/common/test/testing-predicates.h"
 
 namespace common {
 
@@ -21,15 +22,15 @@ class GaussianTest : public ::testing::Test {
 };
 
 TEST_F(GaussianTest, calcMeanAndCovTest) {
-  Eigen::MatrixXd samples(3,3);
+  Eigen::MatrixXd samples(3, 3);
   Eigen::VectorXd weights(3);
   samples << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   weights << 0.2, 0.6, 0.2;
   common::Gaussian gauss(samples, weights);
 
   Eigen::VectorXd true_mean(3);
-  Eigen::MatrixXd true_cov(3,3);
-  true_mean << 2,5,8;
+  Eigen::MatrixXd true_cov(3, 3);
+  true_mean << 2, 5, 8;
   true_cov << 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4;
 
   EXPECT_NEAR_EIGEN(gauss.getMean(), true_mean, 1e-4);

--- a/phaser_common/test/model/function-value-test.cc
+++ b/phaser_common/test/model/function-value-test.cc
@@ -1,15 +1,15 @@
+#include "phaser/model/function-value.h"
+
+#include <Eigen/Dense>
 #include <chrono>
 #include <cmath>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
 #include <memory>
 #include <random>
 
-#include <Eigen/Dense>
-#include <glog/logging.h>
-#include <gtest/gtest.h>
-
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
-#include "phaser/model/function-value.h"
 
 namespace common {
 

--- a/phaser_common/test/utils/signal-utils-test.cc
+++ b/phaser_common/test/utils/signal-utils-test.cc
@@ -1,14 +1,14 @@
-#include <chrono>
-#include <cmath>
-#include <memory>
-#include <random>
+#include "phaser/common/signal-utils.h"
 
 #include <Eigen/Dense>
+#include <chrono>
+#include <cmath>
 #include <fftw3/fftw3.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <random>
 
-#include "phaser/common/signal-utils.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 

--- a/phaser_core/CMakeLists.txt
+++ b/phaser_core/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(phaser_core)
 
-set(CMAKE_CUDA_COMPILER  /usr/local/cuda/bin/nvcc)
-find_package(CUDA REQUIRED)
+if(BUILD_TYPE MATCHES CUDA)
+  set(CMAKE_CUDA_COMPILER  /usr/local/cuda/bin/nvcc)
+  find_package(CUDA REQUIRED)
+endif()
+
 find_package(OpenMP REQUIRED)
 
 include(CheckCXXCompilerFlag)
@@ -74,24 +77,28 @@ cs_add_library(${PROJECT_NAME}_lib
    src/backend/fusion/pyramid-struct.cc
 )
 
- cuda_add_library(${PROJECT_NAME}_cuda_lib
+if(BUILD_TYPE MATCHES CUDA)
+  cuda_add_library(${PROJECT_NAME}_cuda_lib
    src/backend/correlation/spatial-correlation-cuda.cu
- )
+  )
+endif()
 
 #############
 ## TESTING ##
 #############
 
-cuda_add_executable(${PROJECT_NAME}_driver test/driver.cc)
-cuda_add_cufft_to_target(${PROJECT_NAME}_driver)
-target_link_libraries(${PROJECT_NAME}_driver
-  ${PROJECT_NAME}_lib ${PROJECT_NAME}_cuda_lib
-  ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${OpenMP_LIBS})
+if(BUILD_TYPE MATCHES CUDA)
+  cuda_add_executable(${PROJECT_NAME}_driver test/driver.cc)
+  cuda_add_cufft_to_target(${PROJECT_NAME}_driver)
+  target_link_libraries(${PROJECT_NAME}_driver
+    ${PROJECT_NAME}_lib ${PROJECT_NAME}_cuda_lib
+    ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${OpenMP_LIBS})
+endif()
 
 # Sanity check.
 catkin_add_gtest(test_sanity_check test/sanity-check/sanity-check-test.cc)
 target_link_libraries(test_sanity_check
-  ${PROJECT_NAME}_lib)
+  ${PROJECT_NAME}_lib )
 
 catkin_add_gtest(test_laplace_pyramid
   test/fusion/laplace-pyramid-test.cc)

--- a/phaser_core/include/phaser/backend/alignment/base-aligner.h
+++ b/phaser_core/include/phaser/backend/alignment/base-aligner.h
@@ -1,11 +1,11 @@
 #ifndef PHASER_BACKEND_ALIGNMENT_BASE_ALIGNER_H_
 #define PHASER_BACKEND_ALIGNMENT_BASE_ALIGNER_H_
 
-#include "phaser/common/statistics-manager.h"
-#include "phaser/model/point-cloud.h"
-
 #include <memory>
 #include <vector>
+
+#include "phaser/common/statistics-manager.h"
+#include "phaser/model/point-cloud.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/alignment/phase-aligner.h
+++ b/phaser_core/include/phaser/backend/alignment/phase-aligner.h
@@ -2,9 +2,8 @@
 #define PHASER_BACKEND_ALIGNMENT_PHASE_ALIGNER_H_
 
 #include <array>
-#include <vector>
-
 #include <fftw3/fftw3.h>
+#include <vector>
 
 #include "phaser/backend/alignment/base-aligner.h"
 #include "phaser/backend/correlation/spatial-correlation.h"

--- a/phaser_core/include/phaser/backend/correlation/base-spatial-correlation.h
+++ b/phaser_core/include/phaser/backend/correlation/base-spatial-correlation.h
@@ -1,10 +1,9 @@
 #ifndef PHASER_BACKEND_CORRELATION_BASE_SPATIAL_CORRELATION_H_
 #define PHASER_BACKEND_CORRELATION_BASE_SPATIAL_CORRELATION_H_
 
+#include <Eigen/Dense>
 #include <memory>
 #include <vector>
-
-#include <Eigen/Dense>
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/correlation/spatial-correlation-cuda.h
+++ b/phaser_core/include/phaser/backend/correlation/spatial-correlation-cuda.h
@@ -1,14 +1,13 @@
 #ifndef PHASER_BACKEND_CORRELATION_SPATIAL_CORRELATION_CUDA_H_
 #define PHASER_BACKEND_CORRELATION_SPATIAL_CORRELATION_CUDA_H_
 
-#include "phaser/backend/correlation/base-spatial-correlation.h"
-
 #include <array>
-#include <vector>
-
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cufft.h>
+#include <vector>
+
+#include "phaser/backend/correlation/base-spatial-correlation.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/correlation/spatial-correlation.h
+++ b/phaser_core/include/phaser/backend/correlation/spatial-correlation.h
@@ -2,10 +2,9 @@
 #define PHASER_BACKEND_CORRELATION_SPATIAL_CORRELATION_H_
 
 #include <complex>
+#include <fftw3/fftw3.h>
 #include <memory>
 #include <vector>
-
-#include <fftw3/fftw3.h>
 
 #include "phaser/backend/correlation/base-spatial-correlation.h"
 

--- a/phaser_core/include/phaser/backend/correlation/spherical-correlation.h
+++ b/phaser_core/include/phaser/backend/correlation/spherical-correlation.h
@@ -2,11 +2,10 @@
 #define PHASER_BACKEND_CORRELATION_SPHERICAL_CORRELATION_H_
 
 #include <array>
+#include <fftw3/fftw3.h>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <fftw3/fftw3.h>
 
 #include "phaser/common/statistics-manager.h"
 #include "phaser/model/function-value.h"

--- a/phaser_core/include/phaser/backend/fusion/laplace-pyramid.h
+++ b/phaser_core/include/phaser/backend/fusion/laplace-pyramid.h
@@ -3,11 +3,10 @@
 
 #include <array>
 #include <cstdint>
+#include <fftw3/fftw3.h>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <fftw3/fftw3.h>
 
 #include "phaser/backend/fusion/pyramid-struct.h"
 

--- a/phaser_core/include/phaser/backend/registration/base-registration.h
+++ b/phaser_core/include/phaser/backend/registration/base-registration.h
@@ -1,30 +1,27 @@
 #pragma once
 
+#include <memory>
+
+#include "phaser/common/statistics-manager.h"
 #include "phaser/model/point-cloud.h"
 #include "phaser/model/registration-result.h"
-#include "phaser/common/statistics-manager.h"
-#include <memory>
 
 namespace phaser_core {
 
 class BaseRegistration {
-  public:
+ public:
+  virtual ~BaseRegistration() = default;
+  virtual model::RegistrationResult registerPointCloud(
+      model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) = 0;
 
-    virtual ~BaseRegistration() = default;
-    virtual model::RegistrationResult registerPointCloud(
-        model::PointCloudPtr cloud_prev, 
-        model::PointCloudPtr cloud_cur) = 0;
+  virtual void getStatistics(common::StatisticsManager* manager) const noexcept;
 
-    virtual void getStatistics(common::StatisticsManager* manager)
-      const noexcept;
+ protected:
+  BaseRegistration() : statistics_manager_("") {}
+  BaseRegistration(const std::string& reference_name)
+      : statistics_manager_(reference_name) {}
 
-  protected:
-    BaseRegistration() 
-      : statistics_manager_("") {  }
-    BaseRegistration(const std::string& reference_name) 
-      : statistics_manager_(reference_name) {  }
-
-    common::StatisticsManager statistics_manager_;
+  common::StatisticsManager statistics_manager_;
 };
 
 using BaseRegistrationPtr = std::unique_ptr<BaseRegistration>;

--- a/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-cutted.h
+++ b/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-cutted.h
@@ -1,21 +1,21 @@
 #pragma once
 
 #include <memory>
+
 #include "phaser/backend/registration/sph-registration.h"
 
 namespace phaser_core {
 
 class SphRegistrationMockCutted : public SphRegistration {
-  public:
-    virtual ~SphRegistrationMockCutted() = default;
-    virtual model::RegistrationResult registerPointCloud(
-        model::PointCloudPtr cloud_prev,
-        model::PointCloudPtr cloud_cur) override;
+ public:
+  virtual ~SphRegistrationMockCutted() = default;
+  virtual model::RegistrationResult registerPointCloud(
+      model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) override;
 
-   private:
-    model::PointCloudPtr cutPointCloud(
-        common::PointCloud_tPtr& cloud, double min, double max,
-        std::string&& dim);
+ private:
+  model::PointCloudPtr cutPointCloud(
+      common::PointCloud_tPtr& cloud, double min, double max,
+      std::string&& dim);
 };
 
-} // namespace handler
+}  // namespace phaser_core

--- a/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-transformed.h
+++ b/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-transformed.h
@@ -5,13 +5,12 @@
 namespace phaser_core {
 
 class SphRegistrationMockTransformed : public SphRegistration {
-  public:
-    virtual ~SphRegistrationMockTransformed() = default;
-    virtual model::RegistrationResult registerPointCloud(
-        model::PointCloudPtr cloud_prev, 
-        model::PointCloudPtr cloud_cur) override;
+ public:
+  virtual ~SphRegistrationMockTransformed() = default;
+  virtual model::RegistrationResult registerPointCloud(
+      model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) override;
 
-  private:
+ private:
 };
 
 }  // namespace phaser_core

--- a/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-translated.h
+++ b/phaser_core/include/phaser/backend/registration/mock/sph-registration-mock-translated.h
@@ -5,27 +5,27 @@
 namespace phaser_core {
 
 class SphRegistrationMockTranslated : public SphRegistration {
-  public:
-    SphRegistrationMockTranslated();
-    virtual ~SphRegistrationMockTranslated() = default;
-    virtual model::RegistrationResult registerPointCloud(
-        model::PointCloudPtr cloud_prev, 
-        model::PointCloudPtr cloud_cur) override;
+ public:
+  SphRegistrationMockTranslated();
+  virtual ~SphRegistrationMockTranslated() = default;
+  virtual model::RegistrationResult registerPointCloud(
+      model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) override;
 
-    void setRandomTranslation(const double mock_trans_x, 
-        const double mock_trans_y, const double mock_trans_z);
+  void setRandomTranslation(
+      const double mock_trans_x, const double mock_trans_y,
+      const double mock_trans_z);
 
-  private:
-     model::PointCloud pertubPointCloud(model::PointCloud &cloud,
-       const float x, const float y, const float z);
-     
-    std::vector<model::FunctionValue> 
-         pertubFunctionValues(std::vector<model::FunctionValue>& values, 
-         const float x, const float y, const float z);
+ private:
+  model::PointCloud pertubPointCloud(
+      model::PointCloud& cloud, const float x, const float y, const float z);
 
-    double mock_trans_x_;
-    double mock_trans_y_;
-    double mock_trans_z_;
+  std::vector<model::FunctionValue> pertubFunctionValues(
+      std::vector<model::FunctionValue>& values, const float x, const float y,
+      const float z);
+
+  double mock_trans_x_;
+  double mock_trans_y_;
+  double mock_trans_z_;
 };
 
 }  // namespace phaser_core

--- a/phaser_core/include/phaser/backend/registration/sph-opt-registration.h
+++ b/phaser_core/include/phaser/backend/registration/sph-opt-registration.h
@@ -24,8 +24,8 @@ class SphOptRegistration : public BaseRegistration {
   model::RegistrationResult registerPointCloud(
       model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) override;
 
-  void getStatistics(common::StatisticsManager* manager) const
-      noexcept override;
+  void getStatistics(
+      common::StatisticsManager* manager) const noexcept override;
 
   model::RegistrationResult estimateRotation(
       model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur);

--- a/phaser_core/include/phaser/backend/registration/sph-registration.h
+++ b/phaser_core/include/phaser/backend/registration/sph-registration.h
@@ -1,17 +1,17 @@
 #ifndef PHASER_BACKEND_REGISTRATION_SPH_REGISTRATION_H_
 #define PHASER_BACKEND_REGISTRATION_SPH_REGISTRATION_H_
 
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "phaser/backend/alignment/base-aligner.h"
 #include "phaser/backend/correlation/spherical-correlation.h"
 #include "phaser/backend/registration/base-registration.h"
 #include "phaser/backend/uncertainty/base-eval.h"
 #include "phaser/backend/uncertainty/phase-correlation-eval.h"
 #include "phaser/common/spherical-sampler.h"
-
-#include <array>
-#include <memory>
-#include <string>
-#include <vector>
 
 namespace phaser_core {
 
@@ -26,8 +26,8 @@ class SphRegistration : public BaseRegistration {
   model::RegistrationResult registerPointCloud(
       model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur) override;
 
-  void getStatistics(common::StatisticsManager* manager) const
-      noexcept override;
+  void getStatistics(
+      common::StatisticsManager* manager) const noexcept override;
 
   model::RegistrationResult estimateRotation(
       model::PointCloudPtr cloud_prev, model::PointCloudPtr cloud_cur);

--- a/phaser_core/include/phaser/backend/uncertainty/base-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/base-eval.h
@@ -1,12 +1,12 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_BASE_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_BASE_EVAL_H_
 
+#include <memory>
+#include <vector>
+
 #include "phaser/backend/alignment/base-aligner.h"
 #include "phaser/backend/correlation/spherical-correlation.h"
 #include "phaser/distribution/base-distribution.h"
-
-#include <memory>
-#include <vector>
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/bingham-peak-based-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/bingham-peak-based-eval.h
@@ -1,12 +1,12 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_BINGHAM_PEAK_BASED_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_BINGHAM_PEAK_BASED_EVAL_H_
 
+#include <set>
+#include <vector>
+
 #include "phaser/backend/alignment/base-aligner.h"
 #include "phaser/backend/uncertainty/z-score-eval.h"
 #include "phaser/distribution/bingham.h"
-
-#include <set>
-#include <vector>
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/bmm-peak-based-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/bmm-peak-based-eval.h
@@ -1,11 +1,11 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_BMM_PEAK_BASED_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_BMM_PEAK_BASED_EVAL_H_
 
-#include "phaser/backend/uncertainty/z-score-eval.h"
-#include "phaser/distribution/bingham-mixture.h"
-
 #include <set>
 #include <vector>
+
+#include "phaser/backend/uncertainty/z-score-eval.h"
+#include "phaser/distribution/bingham-mixture.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/gaussian-peak-based-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/gaussian-peak-based-eval.h
@@ -1,13 +1,13 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_GAUSSIAN_PEAK_BASED_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_GAUSSIAN_PEAK_BASED_EVAL_H_
 
-#include "phaser/backend/alignment/base-aligner.h"
-#include "phaser/backend/uncertainty/z-score-eval.h"
-#include "phaser/distribution/gaussian.h"
-
 #include <set>
 #include <utility>
 #include <vector>
+
+#include "phaser/backend/alignment/base-aligner.h"
+#include "phaser/backend/uncertainty/z-score-eval.h"
+#include "phaser/distribution/gaussian.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/gmm-peak-based-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/gmm-peak-based-eval.h
@@ -1,15 +1,15 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_GMM_PEAK_BASED_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_GMM_PEAK_BASED_EVAL_H_
 
-#include "phaser/backend/alignment/base-aligner.h"
-#include "phaser/backend/uncertainty/z-score-eval.h"
-#include "phaser/distribution/gaussian-mixture.h"
-#include "phaser/model/gmm-parameters.h"
-
 #include <Eigen/Dense>
 #include <set>
 #include <utility>
 #include <vector>
+
+#include "phaser/backend/alignment/base-aligner.h"
+#include "phaser/backend/uncertainty/z-score-eval.h"
+#include "phaser/distribution/gaussian-mixture.h"
+#include "phaser/model/gmm-parameters.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/peak-based-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/peak-based-eval.h
@@ -2,6 +2,7 @@
 #define PHASER_BACKEND_UNCERTAINTY_PEAK_BASED_EVAL_H_
 
 #include <vector>
+
 #include "phaser/backend/uncertainty/base-peak-extraction.h"
 
 namespace phaser_core {

--- a/phaser_core/include/phaser/backend/uncertainty/phase-correlation-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/phase-correlation-eval.h
@@ -1,11 +1,11 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_PHASE_CORRELATION_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_PHASE_CORRELATION_EVAL_H_
 
+#include <memory>
+
 #include "phaser/backend/alignment/phase-aligner.h"
 #include "phaser/backend/correlation/spherical-correlation.h"
 #include "phaser/backend/uncertainty/base-eval.h"
-
-#include <memory>
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/z-score-eval.h
+++ b/phaser_core/include/phaser/backend/uncertainty/z-score-eval.h
@@ -1,14 +1,14 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_Z_SCORE_EVAL_H_
 #define PHASER_BACKEND_UNCERTAINTY_Z_SCORE_EVAL_H_
 
-#include "phaser/backend/uncertainty/base-eval.h"
-#include "phaser/backend/uncertainty/z-score-peak-extraction.h"
-#include "phaser/common/statistics-manager.h"
-
 #include <cstdint>
 #include <set>
 #include <utility>
 #include <vector>
+
+#include "phaser/backend/uncertainty/base-eval.h"
+#include "phaser/backend/uncertainty/z-score-peak-extraction.h"
+#include "phaser/common/statistics-manager.h"
 
 namespace phaser_core {
 

--- a/phaser_core/include/phaser/backend/uncertainty/z-score-peak-extraction.h
+++ b/phaser_core/include/phaser/backend/uncertainty/z-score-peak-extraction.h
@@ -1,13 +1,13 @@
 #ifndef PHASER_BACKEND_UNCERTAINTY_Z_SCORE_PEAK_EXTRACTION_H_
 #define PHASER_BACKEND_UNCERTAINTY_Z_SCORE_PEAK_EXTRACTION_H_
 
-#include "phaser/backend/uncertainty/base-peak-extraction.h"
-#include "phaser/common/statistics-manager.h"
-
 #include <cstdint>
 #include <set>
 #include <utility>
 #include <vector>
+
+#include "phaser/backend/uncertainty/base-peak-extraction.h"
+#include "phaser/common/statistics-manager.h"
 
 namespace phaser_core {
 

--- a/phaser_core/src/backend/alignment/phase-aligner.cc
+++ b/phaser_core/src/backend/alignment/phase-aligner.cc
@@ -1,19 +1,18 @@
 #include "phaser/backend/alignment/phase-aligner.h"
-#include "phaser/backend/correlation/spatial-correlation-cuda.h"
+
+#include <algorithm>
+#include <chrono>
+#include <complex.h>  // needs to be included before fftw
+#include <glog/logging.h>
+#include <omp.h>
+#include <vector>
+
+#include "igl/histc.h"
 #include "phaser/backend/correlation/spatial-correlation-laplace.h"
 #include "phaser/backend/correlation/spatial-correlation-low-pass.h"
 #include "phaser/common/core-gflags.h"
 #include "phaser/common/point-cloud-utils.h"
 #include "phaser/common/signal-utils.h"
-
-#include <algorithm>
-#include <chrono>
-#include <complex.h>  // needs to be included before fftw
-#include <vector>
-
-#include <glog/logging.h>
-#include <omp.h>
-#include "igl/histc.h"
 
 namespace phaser_core {
 
@@ -57,8 +56,8 @@ void PhaseAligner::alignRegistered(
       &f_reflectivity_,
       &f_ambient_,
   };
-  std::vector<Eigen::VectorXd*> g = {&g_intensities_, &g_ranges_,
-                                     &g_reflectivity_, &g_ambient_};
+  std::vector<Eigen::VectorXd*> g = {
+      &g_intensities_, &g_ranges_, &g_reflectivity_, &g_ambient_};
   discretizePointcloud(cloud_prev, f, &hist_);
   discretizePointcloud(cloud_reg, g, &hist_);
 

--- a/phaser_core/src/backend/correlation/spatial-correlation-cuda.cu
+++ b/phaser_core/src/backend/correlation/spatial-correlation-cuda.cu
@@ -1,10 +1,10 @@
 #include <complex.h>
 #include <cufft.h>
-#include <vector>
-#include "phaser/backend/correlation/spatial-correlation-cuda.h"
-
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <vector>
+
+#include "phaser/backend/correlation/spatial-correlation-cuda.h"
 
 DEFINE_double(phase_gpu_batch, 1, "");
 

--- a/phaser_core/src/backend/correlation/spatial-correlation-low-pass.cc
+++ b/phaser_core/src/backend/correlation/spatial-correlation-low-pass.cc
@@ -1,7 +1,6 @@
 #include "phaser/backend/correlation/spatial-correlation-low-pass.h"
 
 #include <algorithm>
-
 #include <glog/logging.h>
 
 #include "phaser/common/core-gflags.h"

--- a/phaser_core/src/backend/correlation/spatial-correlation.cc
+++ b/phaser_core/src/backend/correlation/spatial-correlation.cc
@@ -1,9 +1,8 @@
 #include "phaser/backend/correlation/spatial-correlation.h"
 
-#include <numeric>
-
 #include <emmintrin.h>
 #include <glog/logging.h>
+#include <numeric>
 
 #include "phaser/common/signal-utils.h"
 

--- a/phaser_core/src/backend/correlation/spherical-correlation-laplace.cc
+++ b/phaser_core/src/backend/correlation/spherical-correlation-laplace.cc
@@ -1,7 +1,6 @@
 #include "phaser/backend/correlation/spherical-correlation-laplace.h"
 
 #include <fstream>
-
 #include <glog/logging.h>
 
 #include "phaser/common/signal-utils.h"

--- a/phaser_core/src/backend/correlation/spherical-correlation.cc
+++ b/phaser_core/src/backend/correlation/spherical-correlation.cc
@@ -1,4 +1,5 @@
 #include "phaser/backend/correlation/spherical-correlation.h"
+
 #include "phaser/model/function-value.h"
 
 extern "C" {
@@ -11,10 +12,9 @@ extern "C" {
 #include "soft/wrap_fftw.h"
 }
 
-#include <glog/logging.h>
-
 #include <algorithm>
 #include <fstream>
+#include <glog/logging.h>
 
 namespace phaser_core {
 

--- a/phaser_core/src/backend/correlation/spherical-range-worker.cc
+++ b/phaser_core/src/backend/correlation/spherical-range-worker.cc
@@ -31,8 +31,8 @@ std::vector<double> SphericalRangeWorker::getCorrelation() const noexcept {
   return sph_corr_.getCorrelation();
 }
 
-const SphericalCorrelation& SphericalRangeWorker::getCorrelationObject() const
-    noexcept {
+const SphericalCorrelation& SphericalRangeWorker::getCorrelationObject()
+    const noexcept {
   return sph_corr_;
 }
 

--- a/phaser_core/src/backend/fusion/laplace-pyramid.cc
+++ b/phaser_core/src/backend/fusion/laplace-pyramid.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
-
 #include <glog/logging.h>
 #include <omp.h>
 

--- a/phaser_core/src/backend/fusion/pyramid-struct.cc
+++ b/phaser_core/src/backend/fusion/pyramid-struct.cc
@@ -1,8 +1,7 @@
 #include "phaser/backend/fusion/pyramid-struct.h"
 
-#include <glog/logging.h>
-
 #include <cmath>
+#include <glog/logging.h>
 
 namespace phaser_core {
 
@@ -41,20 +40,20 @@ std::vector<uint32_t> PyramidStruct::getUpperBounds() const noexcept {
   return upper_bound_per_level_;
 }
 
-uint32_t PyramidStruct::getCoefficientsForLevel(const uint8_t level) const
-    noexcept {
+uint32_t PyramidStruct::getCoefficientsForLevel(
+    const uint8_t level) const noexcept {
   CHECK(level < coefficients_per_level_.size());
   return coefficients_per_level_[level];
 }
 
-uint32_t PyramidStruct::getLowerBoundForLevel(const uint8_t level) const
-    noexcept {
+uint32_t PyramidStruct::getLowerBoundForLevel(
+    const uint8_t level) const noexcept {
   CHECK(level < lower_bound_per_level_.size());
   return lower_bound_per_level_[level];
 }
 
-uint32_t PyramidStruct::getUpperBoundForLevel(const uint8_t level) const
-    noexcept {
+uint32_t PyramidStruct::getUpperBoundForLevel(
+    const uint8_t level) const noexcept {
   CHECK(level < upper_bound_per_level_.size());
   return upper_bound_per_level_[level];
 }

--- a/phaser_core/src/backend/registration/sph-opt-registration.cc
+++ b/phaser_core/src/backend/registration/sph-opt-registration.cc
@@ -1,13 +1,11 @@
 #include "phaser/backend/registration/sph-opt-registration.h"
 
 #include <algorithm>
-#include <iostream>
-
 #include <fftw3/fftw3.h>
 #include <glog/logging.h>
+#include <iostream>
 
 #include "phaser/backend/alignment/phase-aligner.h"
-#include "phaser/backend/correlation/spatial-correlation-cuda.h"
 #include "phaser/backend/correlation/spherical-combined-worker.h"
 #include "phaser/backend/correlation/spherical-intensity-worker.h"
 #include "phaser/backend/correlation/spherical-range-worker.h"
@@ -96,8 +94,8 @@ void SphOptRegistration::estimateTranslation(
   result->setPosUncertaintyEstimate(pos);
 }
 
-void SphOptRegistration::getStatistics(common::StatisticsManager* manager) const
-    noexcept {
+void SphOptRegistration::getStatistics(
+    common::StatisticsManager* manager) const noexcept {
   BaseRegistration::getStatistics(manager);
 }
 

--- a/phaser_core/src/backend/registration/sph-registration.cc
+++ b/phaser_core/src/backend/registration/sph-registration.cc
@@ -1,5 +1,10 @@
-#include "phaser/backend/alignment/phase-aligner.h"
 #include "phaser/backend/registration/sph-registration.h"
+
+#include <algorithm>
+#include <glog/logging.h>
+#include <iostream>
+
+#include "phaser/backend/alignment/phase-aligner.h"
 #include "phaser/backend/uncertainty/bingham-peak-based-eval.h"
 #include "phaser/backend/uncertainty/bmm-peak-based-eval.h"
 #include "phaser/backend/uncertainty/gaussian-peak-based-eval.h"
@@ -7,10 +12,6 @@
 #include "phaser/common/rotation-utils.h"
 #include "phaser/common/statistic-utils.h"
 #include "phaser/common/translation-utils.h"
-
-#include <algorithm>
-#include <glog/logging.h>
-#include <iostream>
 
 DEFINE_int32(
     spherical_bandwith, 75,
@@ -156,8 +157,8 @@ void SphRegistration::estimateTranslation(
   result->setPosUncertaintyEstimate(pos);
 }
 
-void SphRegistration::getStatistics(common::StatisticsManager* manager) const
-    noexcept {
+void SphRegistration::getStatistics(
+    common::StatisticsManager* manager) const noexcept {
   BaseRegistration::getStatistics(manager);
   sph_corr_.getStatistics(manager);
 }

--- a/phaser_core/src/backend/uncertainty/bingham-peak-based-eval.cc
+++ b/phaser_core/src/backend/uncertainty/bingham-peak-based-eval.cc
@@ -1,8 +1,9 @@
 #include "phaser/backend/uncertainty/bingham-peak-based-eval.h"
-#include "phaser/common/rotation-utils.h"
 
 #include <algorithm>
 #include <glog/logging.h>
+
+#include "phaser/common/rotation-utils.h"
 
 DEFINE_int32(
     bingham_peak_neighbors, 0,

--- a/phaser_core/src/backend/uncertainty/bmm-peak-based-eval.cc
+++ b/phaser_core/src/backend/uncertainty/bmm-peak-based-eval.cc
@@ -1,7 +1,8 @@
 #include "phaser/backend/uncertainty/bmm-peak-based-eval.h"
-#include "phaser/common/rotation-utils.h"
 
 #include <glog/logging.h>
+
+#include "phaser/common/rotation-utils.h"
 
 DEFINE_int32(
     bmm_peak_neighbors, 2,

--- a/phaser_core/src/backend/uncertainty/gaussian-peak-based-eval.cc
+++ b/phaser_core/src/backend/uncertainty/gaussian-peak-based-eval.cc
@@ -1,9 +1,10 @@
 #include "phaser/backend/uncertainty/gaussian-peak-based-eval.h"
+
+#include <glog/logging.h>
+
 #include "phaser/common/signal-utils.h"
 #include "phaser/common/translation-utils.h"
 #include "phaser/distribution/gaussian.h"
-
-#include <glog/logging.h>
 
 DEFINE_int32(
     gaussian_peak_neighbors, 0,

--- a/phaser_core/src/backend/uncertainty/gmm-peak-based-eval.cc
+++ b/phaser_core/src/backend/uncertainty/gmm-peak-based-eval.cc
@@ -1,10 +1,11 @@
 #include "phaser/backend/uncertainty/gmm-peak-based-eval.h"
-#include "phaser/backend/uncertainty/gaussian-peak-based-eval.h"
-#include "phaser/common/translation-utils.h"
-#include "phaser/distribution/gaussian.h"
 
 #include <glog/logging.h>
 #include <vector>
+
+#include "phaser/backend/uncertainty/gaussian-peak-based-eval.h"
+#include "phaser/common/translation-utils.h"
+#include "phaser/distribution/gaussian.h"
 
 namespace phaser_core {
 

--- a/phaser_core/src/backend/uncertainty/z-score-eval.cc
+++ b/phaser_core/src/backend/uncertainty/z-score-eval.cc
@@ -1,19 +1,18 @@
 #include "phaser/backend/uncertainty/z-score-eval.h"
-#include "phaser/backend/alignment/phase-aligner.h"
-#include "phaser/backend/uncertainty/signal-analysis.h"
-#include "phaser/distribution/bingham.h"
-#include "phaser/distribution/gaussian.h"
-
-#include "phaser/visualization/plotty-visualizer.h"
 
 #include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <functional>
+#include <glog/logging.h>
 #include <numeric>
 #include <sstream>
 
-#include <glog/logging.h>
+#include "phaser/backend/alignment/phase-aligner.h"
+#include "phaser/backend/uncertainty/signal-analysis.h"
+#include "phaser/distribution/bingham.h"
+#include "phaser/distribution/gaussian.h"
+#include "phaser/visualization/plotty-visualizer.h"
 
 namespace phaser_core {
 

--- a/phaser_core/src/backend/uncertainty/z-score-peak-extraction.cc
+++ b/phaser_core/src/backend/uncertainty/z-score-peak-extraction.cc
@@ -1,13 +1,13 @@
 #include "phaser/backend/uncertainty/z-score-peak-extraction.h"
-#include "phaser/backend/uncertainty/signal-analysis.h"
 
+#include <Eigen/Dense>
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <glog/logging.h>
 #include <numeric>
 
-#include <Eigen/Dense>
-#include <glog/logging.h>
+#include "phaser/backend/uncertainty/signal-analysis.h"
 
 DEFINE_double(
     z_score_lag_percentile, 0.05,

--- a/phaser_core/test/fusion/laplace-pyramid-test.cc
+++ b/phaser_core/test/fusion/laplace-pyramid-test.cc
@@ -1,11 +1,11 @@
+#include "phaser/backend/fusion/laplace-pyramid.h"
+
 #include <chrono>
 #include <cmath>
+#include <gtest/gtest.h>
 #include <memory>
 #include <random>
 
-#include <gtest/gtest.h>
-
-#include "phaser/backend/fusion/laplace-pyramid.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 

--- a/phaser_core/test/fusion/pyramid-struct-test.cc
+++ b/phaser_core/test/fusion/pyramid-struct-test.cc
@@ -1,11 +1,11 @@
+#include "phaser/backend/fusion/pyramid-struct.h"
+
 #include <chrono>
 #include <cmath>
+#include <gtest/gtest.h>
 #include <memory>
 #include <random>
 
-#include <gtest/gtest.h>
-
-#include "phaser/backend/fusion/pyramid-struct.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 

--- a/phaser_core/test/sanity-check/sanity-check-test.cc
+++ b/phaser_core/test/sanity-check/sanity-check-test.cc
@@ -1,6 +1,6 @@
-#include "phaser/common/test/testing-entrypoint.h"
-
 #include <gtest/gtest.h>
+
+#include "phaser/common/test/testing-entrypoint.h"
 
 namespace phaser_core {
 

--- a/phaser_core/test/translation-alignment/spatial-correlation-test.cc
+++ b/phaser_core/test/translation-alignment/spatial-correlation-test.cc
@@ -1,8 +1,4 @@
 #include "phaser/backend/correlation/spatial-correlation.h"
-#include "phaser/common/signal-utils.h"
-#include "phaser/common/test/testing-entrypoint.h"
-#include "phaser/common/test/testing-predicates.h"
-#include "phaser/common/translation-utils.h"
 
 #include <algorithm>
 #include <chrono>
@@ -10,6 +6,11 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
+
+#include "phaser/common/signal-utils.h"
+#include "phaser/common/test/testing-entrypoint.h"
+#include "phaser/common/test/testing-predicates.h"
+#include "phaser/common/translation-utils.h"
 
 namespace phaser_core {
 

--- a/phaser_core/test/uncertainty-estimate/rot-bingham-test.cc
+++ b/phaser_core/test/uncertainty-estimate/rot-bingham-test.cc
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include "phaser/backend/registration/sph-registration.h"
 #include "phaser/backend/uncertainty/z-score-eval.h"
 #include "phaser/common/data/datasource-ply.h"
@@ -5,8 +7,6 @@
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/distribution/bingham.h"
-
-#include <gtest/gtest.h>
 
 namespace phaser_core {
 

--- a/phaser_core/test/uncertainty-estimate/rot-bmm-test.cc
+++ b/phaser_core/test/uncertainty-estimate/rot-bmm-test.cc
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include "phaser/backend/registration/sph-registration.h"
 #include "phaser/backend/uncertainty/z-score-eval.h"
 #include "phaser/common/data/datasource-ply.h"
@@ -5,8 +7,6 @@
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/distribution/bingham-mixture.h"
-
-#include <gtest/gtest.h>
 
 namespace phaser_core {
 

--- a/phaser_core/test/uncertainty-estimate/trans-gauss-test.cc
+++ b/phaser_core/test/uncertainty-estimate/trans-gauss-test.cc
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include "phaser/backend/registration/sph-registration.h"
 #include "phaser/backend/uncertainty/z-score-eval.h"
 #include "phaser/common/data/datasource-ply.h"
@@ -5,8 +7,6 @@
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/distribution/gaussian.h"
-
-#include <gtest/gtest.h>
 
 namespace phaser_core {
 

--- a/phaser_core/test/uncertainty-estimate/trans-gm-test.cc
+++ b/phaser_core/test/uncertainty-estimate/trans-gm-test.cc
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include "phaser/backend/registration/sph-registration.h"
 #include "phaser/backend/uncertainty/z-score-eval.h"
 #include "phaser/common/data/datasource-ply.h"
@@ -5,8 +7,6 @@
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/distribution/gaussian-mixture.h"
-
-#include <gtest/gtest.h>
 
 namespace phaser_core {
 

--- a/phaser_pre/include/phaser_pre/algorithm/angle-based-ground-removal.h
+++ b/phaser_pre/include/phaser_pre/algorithm/angle-based-ground-removal.h
@@ -2,6 +2,7 @@
 #define PHASER_PRE_ALGORITHM_ANGLE_BASED_GROUND_REMOVAL_H_
 
 #include <opencv2/core/mat.hpp>
+
 #include "phaser/model/point-cloud.h"
 #include "phaser_pre/common/vec-helper.h"
 #include "phaser_pre/model/ground-removal-result.h"

--- a/phaser_pre/include/phaser_pre/algorithm/cluster-points.h
+++ b/phaser_pre/include/phaser_pre/algorithm/cluster-points.h
@@ -1,9 +1,8 @@
 #ifndef PHASER_PRE_ALGORITHM_CLUSTER_POINTS_H_
 #define PHASER_PRE_ALGORITHM_CLUSTER_POINTS_H_
 
-#include <vector>
-
 #include <opencv2/core/mat.hpp>
+#include <vector>
 
 #include "phaser/model/point-cloud.h"
 #include "phaser_pre/common/vec-helper.h"

--- a/phaser_pre/include/phaser_pre/cloud-pre-processor.h
+++ b/phaser_pre/include/phaser_pre/cloud-pre-processor.h
@@ -2,6 +2,7 @@
 #define PHASER_PRE_CLOUD_PRE_PROCESSOR_H_
 
 #include <vector>
+
 #include "phaser_pre/common/base-command.h"
 #include "phaser_pre/common/base-pre-processor.h"
 

--- a/phaser_pre/include/phaser_pre/common/sse-mathfun.h
+++ b/phaser_pre/include/phaser_pre/common/sse-mathfun.h
@@ -50,12 +50,12 @@ typedef __m64 v2si;  // vector of 2 int (mmx)
 #endif
 
 /* declare some SSE constants -- why can't I figure a better way to do that? */
-#define _PS_CONST(Name, Val)                                                 \
-  static const ALIGN16_BEG float _ps_##Name[4] ALIGN16_END = {Val, Val, Val, \
-                                                              Val}
-#define _PI32_CONST(Name, Val)                                               \
-  static const ALIGN16_BEG int _pi32_##Name[4] ALIGN16_END = {Val, Val, Val, \
-                                                              Val}
+#define _PS_CONST(Name, Val)                                   \
+  static const ALIGN16_BEG float _ps_##Name[4] ALIGN16_END = { \
+      Val, Val, Val, Val}
+#define _PI32_CONST(Name, Val)                                 \
+  static const ALIGN16_BEG int _pi32_##Name[4] ALIGN16_END = { \
+      Val, Val, Val, Val}
 #define _PS_CONST_TYPE(Name, Type, Val) \
   static const ALIGN16_BEG Type _ps_##Name[4] ALIGN16_END = {Val, Val, Val, Val}
 

--- a/phaser_pre/src/algorithm/image-gradient.cc
+++ b/phaser_pre/src/algorithm/image-gradient.cc
@@ -1,5 +1,7 @@
 #include "phaser_pre/algorithm/image-gradient.h"
+
 #include <opencv2/highgui/highgui.hpp>
+
 #include "opencv2/imgproc.hpp"
 
 namespace preproc {

--- a/phaser_pre/src/algorithm/image-projection.cc
+++ b/phaser_pre/src/algorithm/image-projection.cc
@@ -1,7 +1,6 @@
 #include "phaser_pre/algorithm/image-projection.h"
 
 #include <chrono>
-
 #include <glog/logging.h>
 
 #define USE_SSE2

--- a/phaser_pre/src/common/sse-mathfun-extension.cc
+++ b/phaser_pre/src/common/sse-mathfun-extension.cc
@@ -61,6 +61,7 @@ is < 2e-7 and atan2_ps max deviation is < 2.5e-7
 
 #define USE_SSE2
 #include "phaser_pre/common/sse-mathfun-extension.h"
+
 #include "phaser_pre/common/sse-mathfun.h"
 
 namespace preproc {

--- a/phaser_pre/src/common/sse-mathfun.cc
+++ b/phaser_pre/src/common/sse-mathfun.cc
@@ -29,9 +29,9 @@
   (this is the zlib license)
 */
 
-#include <xmmintrin.h>
-
 #include "phaser_pre/common/sse-mathfun.h"
+
+#include <xmmintrin.h>
 
 namespace preproc {
 

--- a/phaser_pre/test/angle-based-ground-removal-test.cc
+++ b/phaser_pre/test/angle-based-ground-removal-test.cc
@@ -1,18 +1,18 @@
-#include <chrono>
-#include <cmath>
-#include <gtest/gtest.h>
-#include <memory>
-#include <random>
+#include "phaser_pre/algorithm/angle-based-ground-removal.h"
 
 #include <Eigen/Dense>
+#include <chrono>
+#include <cmath>
 #include <eigen-checks/gtest.h>
+#include <gtest/gtest.h>
+#include <memory>
 #include <opencv2/core/eigen.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/model/point-cloud.h"
-#include "phaser_pre/algorithm/angle-based-ground-removal.h"
 #include "phaser_pre/algorithm/image-projection.h"
 
 namespace preproc {

--- a/phaser_pre/test/cloud-pre-processor-test.cc
+++ b/phaser_pre/test/cloud-pre-processor-test.cc
@@ -1,3 +1,5 @@
+#include "phaser_pre/cloud-pre-processor.h"
+
 #include <chrono>
 #include <cmath>
 #include <gtest/gtest.h>
@@ -7,7 +9,6 @@
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/model/point-cloud.h"
-#include "phaser_pre/cloud-pre-processor.h"
 
 namespace preproc {
 

--- a/phaser_pre/test/cluster-points-test.cc
+++ b/phaser_pre/test/cluster-points-test.cc
@@ -1,18 +1,18 @@
-#include <chrono>
-#include <cmath>
-#include <gtest/gtest.h>
-#include <memory>
-#include <random>
+#include "phaser_pre/algorithm/cluster-points.h"
 
 #include <Eigen/Dense>
+#include <chrono>
+#include <cmath>
 #include <eigen-checks/gtest.h>
+#include <gtest/gtest.h>
+#include <memory>
 #include <opencv2/core/eigen.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/model/point-cloud.h"
-#include "phaser_pre/algorithm/cluster-points.h"
 #include "phaser_pre/algorithm/image-projection.h"
 
 namespace preproc {

--- a/phaser_pre/test/image-gradient-test.cc
+++ b/phaser_pre/test/image-gradient-test.cc
@@ -1,21 +1,21 @@
+#include "phaser_pre/algorithm/image-gradient.h"
+
+#include <Eigen/Dense>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 #include <memory>
-#include <random>
-
-#include <Eigen/Dense>
-#include <eigen-checks/gtest.h>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/model/point-cloud.h"
-#include "phaser_pre/algorithm/image-gradient.h"
 #include "phaser_pre/algorithm/image-projection.h"
 
 namespace preproc {

--- a/phaser_pre/test/image-projection-test.cc
+++ b/phaser_pre/test/image-projection-test.cc
@@ -1,19 +1,19 @@
-#include <chrono>
-#include <cmath>
-#include <gtest/gtest.h>
-#include <memory>
-#include <random>
+#include "phaser_pre/algorithm/image-projection.h"
 
 #include <Eigen/Dense>
+#include <chrono>
+#include <cmath>
 #include <eigen-checks/gtest.h>
+#include <gtest/gtest.h>
+#include <memory>
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"
 #include "phaser/common/test/testing-predicates.h"
 #include "phaser/model/point-cloud.h"
-#include "phaser_pre/algorithm/image-projection.h"
 
 namespace preproc {
 

--- a/phaser_pre/test/loam-feature-extraction-test.cc
+++ b/phaser_pre/test/loam-feature-extraction-test.cc
@@ -1,13 +1,12 @@
+#include <Eigen/Dense>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 #include <memory>
-#include <random>
-
-#include <Eigen/Dense>
-#include <eigen-checks/gtest.h>
 #include <opencv2/core/eigen.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"

--- a/phaser_pre/test/mark-occluded-test.cc
+++ b/phaser_pre/test/mark-occluded-test.cc
@@ -1,13 +1,14 @@
+#include "phaser_pre/algorithm/mark-occluded.h"
+
+#include <Eigen/Dense>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 #include <memory>
-#include <random>
-
-#include <Eigen/Dense>
-#include <eigen-checks/gtest.h>
 #include <opencv2/core/eigen.hpp>
+#include <random>
 
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/test/testing-entrypoint.h"
@@ -17,7 +18,6 @@
 #include "phaser_pre/algorithm/cloud-segmentation.h"
 #include "phaser_pre/algorithm/cluster-points.h"
 #include "phaser_pre/algorithm/image-projection.h"
-#include "phaser_pre/algorithm/mark-occluded.h"
 
 namespace preproc {
 

--- a/phaser_ros/app/phaser-app.cc
+++ b/phaser_ros/app/phaser-app.cc
@@ -1,11 +1,10 @@
-#include "phaser/common/gflags-interface.h"
-#include "phaser/phaser-node.h"
-
+#include <chrono>
 #include <glog/logging.h>
 #include <ros/ros.h>
-
-#include <chrono>
 #include <thread>
+
+#include "phaser/common/gflags-interface.h"
+#include "phaser/phaser-node.h"
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "phaser");

--- a/phaser_ros/include/phaser/phaser-node.h
+++ b/phaser_ros/include/phaser/phaser-node.h
@@ -1,16 +1,16 @@
 #ifndef PHASER_PHASER_NODE_H_
 #define PHASER_PHASER_NODE_H_
 
-#include "phaser/common/data/base-datasource.h"
-#include "phaser/common/statistics-manager.h"
-#include "phaser/controller/cloud-controller.h"
-#include "phaser/model/point-cloud.h"
-
 #include <atomic>
 #include <memory>
 #include <ros/ros.h>
 #include <string>
 #include <vector>
+
+#include "phaser/common/data/base-datasource.h"
+#include "phaser/common/statistics-manager.h"
+#include "phaser/controller/cloud-controller.h"
+#include "phaser/model/point-cloud.h"
 
 namespace phaser_ros {
 

--- a/phaser_ros/src/phaser-node.cc
+++ b/phaser_ros/src/phaser-node.cc
@@ -1,4 +1,8 @@
 #include "phaser/phaser-node.h"
+
+#include <glog/logging.h>
+#include <ros/ros.h>
+
 #include "phaser/backend/registration/mock/sph-registration-mock-cutted.h"
 #include "phaser/backend/registration/mock/sph-registration-mock-rotated.h"
 #include "phaser/backend/registration/mock/sph-registration-mock-transformed.h"
@@ -8,9 +12,6 @@
 #include "phaser/common/data/datasource-ply.h"
 #include "phaser/common/data/datasource-ros.h"
 #include "phaser/visualization/plotty-visualizer.h"
-
-#include <glog/logging.h>
-#include <ros/ros.h>
 
 namespace phaser_ros {
 
@@ -85,8 +86,8 @@ void PhaserNode::initializeDatasource(const std::string& type) {
     LOG(FATAL) << "Unknown datasource type specified.";
 }
 
-std::vector<common::StatisticsManager> PhaserNode::retrieveStatistics() const
-    noexcept {
+std::vector<common::StatisticsManager> PhaserNode::retrieveStatistics()
+    const noexcept {
   std::vector<common::StatisticsManager> managers;
 
   return managers;

--- a/phaser_viz/include/phaser/visualization/plotty-visualizer.h
+++ b/phaser_viz/include/phaser/visualization/plotty-visualizer.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+
 #include "phaser/common/statistics-manager.h"
 
 namespace visualization {

--- a/phaser_viz/src/visualization/plotty-visualizer.cc
+++ b/phaser_viz/src/visualization/plotty-visualizer.cc
@@ -1,9 +1,9 @@
 #include "phaser/visualization/plotty-visualizer.h"
-#include <plotty/matplotlibcpp.hpp>
 
 #include <Eigen/Dense>
 #include <fstream>
 #include <glog/logging.h>
+#include <plotty/matplotlibcpp.hpp>
 
 namespace visualization {
 


### PR DESCRIPTION
## General

This PR removes the Cuda requirement from the current compilation pipeline. It is still supported in the CMAKE file when passing the correct flags.